### PR TITLE
ci(dependabot): auto-analyse and merge Dependabot PRs, harden workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,19 +23,29 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2
+        # Audit mode records all egress without blocking, so the build cannot break. After
+        # the first run, open the run's harden-runner insights, copy the observed endpoints
+        # into `allowed-endpoints:`, and switch `egress-policy` to `block` to stop a
+        # compromised dependency (worm) from exfiltrating SONAR_TOKEN / GITHUB_TOKEN.
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0  # Shallow clones should be disabled for better SonarQube analysis
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Cache Maven packages
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         id: maven-cache
         with:
           path: ~/.m2/repository
@@ -44,7 +54,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Cache SonarQube packages
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
@@ -66,7 +76,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: test-results
           path: |
@@ -76,7 +86,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: coverage-reports
           path: |
@@ -95,7 +105,7 @@ jobs:
 
       - name: SonarQube Scan
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: SonarSource/sonarqube-scan-action@v8.2.0
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -108,17 +118,27 @@ jobs:
     needs: build-and-test
 
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2
+        # Audit mode records all egress without blocking, so the build cannot break. After
+        # the first run, open the run's harden-runner insights, copy the observed endpoints
+        # into `allowed-endpoints:`, and switch `egress-policy` to `block` to stop a
+        # compromised dependency (worm) from exfiltrating SONAR_TOKEN / GITHUB_TOKEN.
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Cache Maven packages
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -126,7 +146,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Download coverage reports
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: coverage-reports
           path: target/
@@ -142,17 +162,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2
+        # Audit mode records all egress without blocking, so the build cannot break. After
+        # the first run, open the run's harden-runner insights, copy the observed endpoints
+        # into `allowed-endpoints:`, and switch `egress-policy` to `block` to stop a
+        # compromised dependency (worm) from exfiltrating SONAR_TOKEN / GITHUB_TOKEN.
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Cache Maven packages
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,232 @@
+name: Dependabot Auto-Merge
+
+# Runs after the "CI/CD Pipeline" workflow finishes on a Dependabot pull request.
+# Dependabot PRs run with a read-only token and are denied repository secrets on the
+# `pull_request` event, so we cannot analyse or merge from there. `workflow_run` fires in
+# the trusted context of the base repo (full secrets + a write-capable GITHUB_TOKEN) once
+# CI has completed, which also lets us gate on the CI status checks having passed.
+on:
+  workflow_run:
+    workflows: ["CI/CD Pipeline"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # Gate 1: only proceed when CI succeeded on a Dependabot pull request.
+  guard:
+    name: Verify CI passed on a Dependabot PR
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.triggering_actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/')
+    outputs:
+      pr_number: ${{ steps.pr.outputs.number }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+
+      - name: Resolve the pull request for this branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          # Re-verify the author against the API (defence in depth): the PR must exist,
+          # be open, and be authored by Dependabot before anything downstream runs.
+          pr=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "$HEAD_BRANCH" \
+            --state open \
+            --author "app/dependabot" \
+            --json number \
+            --jq '.[0].number')
+          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+            echo "No open Dependabot PR found for branch $HEAD_BRANCH; nothing to do."
+            echo "number=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Resolved PR #$pr"
+            echo "number=$pr" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Gate 2: let Claude Code review the change for deprecations / breaking changes.
+  analyse:
+    name: Analyse PR with Claude Code
+    runs-on: ubuntu-latest
+    needs: guard
+    if: needs.guard.outputs.pr_number != ''
+    outputs:
+      verdict: ${{ steps.review.outputs.verdict }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2
+        # This job installs a third-party CLI and runs it with CLAUDE_CODE_OAUTH_TOKEN in
+        # scope, so it is the softest target here. Audit first because the npm install and
+        # the CLI's own runtime egress are hard to enumerate up front; after the first run,
+        # lift the observed endpoints (registry.npmjs.org, api.anthropic.com, github.com, …)
+        # into `allowed-endpoints:` and switch to `egress-policy: block`.
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Determine PR head SHA
+        id: meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha=$(gh pr view "${{ needs.guard.outputs.pr_number }}" \
+            --repo "${{ github.repository }}" \
+            --json headRefOid --jq '.headRefOid')
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR head
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ steps.meta.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+
+      - name: Install Claude Code CLI
+        # Pin the exact version so the postinstall that runs (node install.cjs, which the
+        # package requires to fetch its binary) is a known, auditable release rather than
+        # whatever "latest" resolves to. Dependabot updates this pin like any dependency.
+        # This step deliberately has no secrets in scope, so an install-time compromise
+        # cannot read a token; the CLI is only invoked with the token in the next step.
+        run: npm install -g @anthropic-ai/claude-code@2.1.207
+
+      - name: Analyse the dependency update
+        id: review
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.guard.outputs.pr_number }}
+        run: |
+          gh pr diff "$PR_NUMBER" --repo "${{ github.repository }}" > pr.diff
+          gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" \
+            --json title,body --jq '"# " + .title + "\n\n" + (.body // "")' > pr.md
+
+          PROMPT=$(cat <<'EOF'
+          You are reviewing a Dependabot dependency-update pull request for this Maven
+          multi-module Java project. The PR title/body is in `pr.md` and the change is in
+          `pr.diff`. Use your read-only tools (Read, Grep, Glob) to inspect how the affected
+          dependency is used across the codebase.
+
+          Assess whether this update is safe to merge automatically. Flag anything that could
+          break the project, specifically:
+            - Removed, renamed, or deprecated APIs the project actually calls.
+            - Breaking changes across a major version bump.
+            - Behavioural changes in transitive dependencies that affect our usage.
+            - Changed minimum Java version or other build requirements.
+
+          A patch/minor bump with no impacted usage is normally a PASS. A major bump, or any
+          update that touches an API the project uses in a breaking way, is a FAIL.
+
+          Write a short, specific rationale. Then, as the very last line of your response,
+          output exactly one of:
+          VERDICT: PASS
+          VERDICT: FAIL
+          EOF
+          )
+
+          set +e
+          claude -p "$PROMPT" \
+            --model claude-sonnet-5 \
+            --allowedTools "Read,Grep,Glob" \
+            --output-format text | tee analysis.txt
+          status=$?
+          set -e
+
+          if [ $status -ne 0 ]; then
+            echo "Claude CLI exited with status $status; treating as FAIL."
+            echo "verdict=FAIL" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          verdict=$(grep -Eio 'VERDICT: (PASS|FAIL)' analysis.txt | tail -n1 | awk '{print $2}')
+          if [ -z "$verdict" ]; then
+            echo "No verdict found in analysis; treating as FAIL."
+            verdict="FAIL"
+          fi
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+
+      - name: Post analysis as a PR comment
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.guard.outputs.pr_number }}
+        run: |
+          {
+            echo "## 🤖 Claude Code dependency analysis"
+            echo
+            echo "**Verdict:** ${{ steps.review.outputs.verdict || 'FAIL (analysis did not complete)' }}"
+            echo
+            if [ -f analysis.txt ]; then
+              cat analysis.txt
+            fi
+          } > comment.md
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body-file comment.md
+
+  # Both gates passed (CI success is the trigger, analysis is PASS): merge.
+  # The default GITHUB_TOKEN cannot satisfy the "Require review from Code Owners" rule,
+  # so we mint a short-lived token for a dedicated GitHub App that is on the branch
+  # ruleset's bypass list.
+  #
+  # The App credentials live ONLY in the `dependabot-merge` environment, whose deployment
+  # branch policy allows the default branch (master) exclusively. Because `workflow_run`
+  # jobs run in the default-branch context, this job can read them — but any workflow added
+  # or altered in a pull request runs from the PR ref and is denied the environment, so it
+  # cannot borrow the App token to approve its own PR. The secret, not the workflow logic,
+  # is the security boundary.
+  merge:
+    name: Merge PR
+    runs-on: ubuntu-latest
+    needs: [guard, analyse]
+    if: needs.analyse.outputs.verdict == 'PASS'
+    environment: dependabot-merge
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.MERGE_APP_ID }}
+          private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}
+
+      - name: Approve and squash-merge the Dependabot PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ needs.guard.outputs.pr_number }}
+        run: |
+          gh pr review "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --approve \
+            --body "Approved automatically: CI passed and Claude Code analysis returned PASS."
+          gh pr merge "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --squash \
+            --delete-branch

--- a/docs/CI-CD-SETUP.md
+++ b/docs/CI-CD-SETUP.md
@@ -149,6 +149,147 @@ mvn sonar:sonar \
 
 ---
 
+## 🤝 Dependabot Auto-Merge
+
+**Location**: `.github/workflows/dependabot-auto-merge.yml`
+
+Dependabot dependency-update PRs are analysed by Claude Code and merged automatically when
+both CI **and** the analysis pass. Anything risky is left for manual review — nothing is
+merged silently.
+
+### How it is triggered
+
+The workflow uses the **`workflow_run`** trigger on the **CI/CD Pipeline** workflow, not
+`pull_request`. This is deliberate:
+
+- Dependabot PRs run with a **read-only token and no repository secrets** on `pull_request`
+  (GitHub's guard against secret exfiltration via a malicious dependency). That context can
+  neither run the analysis (needs `CLAUDE_CODE_OAUTH_TOKEN`) nor merge.
+- `workflow_run` fires **after** CI completes and runs in the **trusted default-branch
+  context** with full secrets and a write-capable token. It also inherently gates on CI
+  having passed — the workflow only proceeds when the pipeline's `conclusion` is `success`.
+
+### The three gates
+
+```
+Dependabot opens PR ──▶ CI/CD Pipeline runs ──▶ completes
+                                                    │ workflow_run
+                                                    ▼
+   guard ──────────▶ analyse ────────────▶ merge
+   CI success +      Claude Code review     Approve + squash-merge
+   Dependabot        (posts a PR comment,   via a scoped GitHub App
+   author/actor +    verdict PASS/FAIL)     identity; delete branch
+   same-repo head
+```
+
+1. **guard** — proceeds only when the CI run succeeded, the author **and** triggering actor
+   are `dependabot[bot]`, and the head is a same-repo (non-fork) `dependabot/*` branch. It
+   re-verifies the PR author against the API as defence in depth.
+2. **analyse** — runs the Claude Code CLI (`claude-sonnet-5`, restricted to the read-only
+   `Read,Grep,Glob` tools) over the diff to flag deprecated/removed APIs, breaking changes,
+   and impacted usages. It posts its findings as a PR comment and emits a `PASS`/`FAIL`
+   verdict. Any error, timeout, or missing verdict is treated as **FAIL** (fail-safe: the PR
+   is not merged).
+3. **merge** — only when the verdict is `PASS`: mints a short-lived token for a dedicated
+   GitHub App, submits an approving review, and squash-merges with branch deletion.
+
+### Why a GitHub App merges (and not `GITHUB_TOKEN`)
+
+`master` requires a Code Owner review (see `.github/CODEOWNERS`), which the default
+`GITHUB_TOKEN` cannot satisfy. A dedicated **GitHub App** on the ruleset **bypass list**
+provides the merge identity — least privilege (`contents` + `pull_requests` write only),
+short-lived tokens, no personal PAT.
+
+The App credentials live **only** in the `dependabot-merge` Actions **environment**, whose
+deployment-branch policy allows the default branch (`master`) exclusively. Because
+`workflow_run` jobs run in the default-branch context they can read them, but any workflow
+added or altered in a PR runs from the PR ref and is **denied** the environment — so it
+cannot borrow the App token to approve its own PR. The secret, not the workflow logic, is the
+security boundary.
+
+### Supply-chain hardening
+
+Both `ci.yml` and this workflow are hardened against dependency worms (e.g. Shai-Hulud):
+
+- **All actions are pinned by commit SHA** (with a `# vN` comment); Dependabot's
+  `github-actions` ecosystem keeps the pins updated.
+- **`step-security/harden-runner`** runs first in every job — `block` with a minimal
+  egress allowlist on the GitHub-API-only jobs (`guard`, `merge`), and `audit` on the
+  broad-egress jobs (CI builds, `analyse`) pending endpoint discovery. See "Promoting
+  harden-runner to block" below.
+- The **Claude Code CLI is pinned to an exact version** and installed in a step with **no
+  secrets in scope**, so an install-time (`postinstall`) compromise cannot read a token; the
+  token is only present when the CLI is actually invoked.
+
+### Required setup
+
+Add these in **Settings**:
+
+| Item | Where | Notes |
+|------|-------|-------|
+| `CLAUDE_CODE_OAUTH_TOKEN` | Actions secret (repo) | Used by the `analyse` job. Set a spend limit and rotate periodically. |
+| GitHub App | Developer settings → GitHub Apps | Permissions: **Contents** + **Pull requests** = Read and write only. Install on this repo. |
+| `MERGE_APP_ID`, `MERGE_APP_PRIVATE_KEY` | **`dependabot-merge` environment** secrets | The App's ID and full `.pem` private key. Environment deployment branches restricted to `master`. |
+| Ruleset bypass | Settings → Rules → Rulesets (`master`) | Add the GitHub App to the **bypass list**. |
+| Actions PR approval | Settings → Actions → General | Enable "Allow GitHub Actions to create and approve pull requests". |
+
+### Promoting harden-runner to `block`
+
+`audit` **records** egress but does not block it. After the first CI run and the first
+Dependabot analysis, open the run's **harden-runner insights**, copy the observed endpoints
+into the job's `allowed-endpoints:`, and switch `egress-policy` to `block`. That is when the
+exfiltration path actually closes.
+
+### Opting a PR out
+
+To stop auto-merge for a specific update, review it manually before CI finishes, or convert
+the analysis to `FAIL` by requesting changes / closing. A `FAIL` verdict (or any analysis
+error) always blocks the merge; the reasoning is visible in the PR comment.
+
+### Operating the auto-merge
+
+**A PR that needs human changes becomes a manual merge — automatically.** The `guard` job
+requires *both* `workflow_run.actor` **and** `triggering_actor` to be `dependabot[bot]`. The
+moment you push a commit to a `dependabot/*` branch to adapt the code, the next CI run's
+triggering actor is **you**, so auto-merge disengages and the PR reverts to a normal manual
+merge (you are the Code Owner). Dependabot also stops managing a branch once a human pushes to
+it. `@dependabot rebase` / `@dependabot recreate` are *not* human pushes — Dependabot performs
+them, so the branch stays auto-merge-eligible; only your own commits disengage it.
+
+**Re-triggering / onboarding existing PRs.** `workflow_run` only fires for CI runs that
+complete *after* this workflow is on `master`, so PRs opened earlier are not evaluated until a
+fresh, Dependabot-authored CI run occurs. Note:
+
+- **Re-running the CI workflow manually does not work** — on a re-run GitHub sets
+  `triggering_actor` to the person who clicked re-run, so the `guard` intentionally skips it.
+  This is the check that stops anyone forcing an auto-merge by re-running CI.
+- **Use a Dependabot command instead**, which makes Dependabot itself produce the new run:
+  **`@dependabot recreate`** (rebuilds the PR + branch, guaranteeing a fresh CI run) is the
+  reliable choice for onboarding. `@dependabot rebase` no-ops when the branch is already up to
+  date, so it may not trigger a run.
+
+**Bulk onboarding (one-off).** After this workflow first lands on `master`, refresh the
+already-open Dependabot PRs from your own machine — under *your* write identity, so no stored
+credential is involved. A mise task wraps this:
+
+```bash
+mise run dependabot:rebase            # comments "@dependabot rebase" on every open Dependabot PR
+mise run dependabot:rebase recreate   # use "recreate" to force a fresh CI run when a branch is already current
+```
+
+It resolves the repo from `gh`, requires you to be logged in (`gh auth login`), and only ever
+comments — it holds no token of its own.
+
+> **Why not a workflow for this?** Dependabot **ignores `@dependabot` commands authored by
+> `github-actions[bot]`** (the default `GITHUB_TOKEN`), so a comment-posting workflow would
+> need a stored PAT or GitHub App whose identity Dependabot accepts — reintroducing a
+> high-value, exfiltration-worthy credential for what is a rare, one-off task. A scheduled
+> version would also remove the last human touchpoint, creating a fully autonomous merge-to-
+> `master` loop. Prefer the local `gh` loop above; it uses your existing identity and adds no
+> secret and no new attack surface.
+
+---
+
 ## 🚀 Setting Up CI/CD
 
 ### 1. GitHub Repository Setup

--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,16 @@ A Java 25 booking engine project using Maven multi-module architecture, Spring B
 
 ## Recent Changes (Last 2 Weeks)
 
+### Latest Commit: docs(dependabot): document auto-merge flow and add rebase mise task
+**Date:** Jul 13, 2026
+**Commit:** 14e51b3
+
+**Changed files:**
+- docs/CI-CD-SETUP.md
+- mise.toml
+
+---
+
 ### Latest Commit: ci(dependabot): auto-analyse and merge Dependabot PRs, harden workflows
 **Date:** Jul 13, 2026
 **Commit:** 852f916

--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,16 @@ A Java 25 booking engine project using Maven multi-module architecture, Spring B
 
 ## Recent Changes (Last 2 Weeks)
 
+### Latest Commit: ci(dependabot): auto-analyse and merge Dependabot PRs, harden workflows
+**Date:** Jul 13, 2026
+**Commit:** 852f916
+
+**Changed files:**
+- .github/workflows/ci.yml
+- .github/workflows/dependabot-auto-merge.yml
+
+---
+
 ### Latest Commit: fix: remove sonar from maven configuration
 **Date:** Jul 10, 2026
 **Commit:** 92d27a0

--- a/mise.toml
+++ b/mise.toml
@@ -35,3 +35,41 @@ run = "pre-commit autoupdate"
 [tasks."sonar"]
 description = "Run a sonar scanner analysis"
 run = "sonar-scanner -Dspotless.check.skip=true"
+
+[tasks."dependabot:rebase"]
+description = "Ask Dependabot to rebase (or recreate) every open Dependabot PR, so the auto-merge workflow re-evaluates them. Runs under your own gh identity — no stored token. Usage: mise run dependabot:rebase [rebase|recreate]"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+
+command="${1:-rebase}"
+case "$command" in
+  rebase|recreate) ;;
+  *) echo "error: expected 'rebase' or 'recreate', got '$command'" >&2; exit 1 ;;
+esac
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: GitHub CLI (gh) is not installed" >&2; exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "error: not logged in to gh — run 'gh auth login' first" >&2; exit 1
+fi
+
+repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+
+mapfile -t prs < <(
+  gh pr list --repo "$repo" --author "app/dependabot" --state open \
+    --json number --jq '.[].number'
+)
+
+if [ "${#prs[@]}" -eq 0 ]; then
+  echo "No open Dependabot PRs in $repo."
+  exit 0
+fi
+
+echo "Commenting '@dependabot $command' on ${#prs[@]} PR(s) in $repo:"
+for n in "${prs[@]}"; do
+  gh pr comment "$n" --repo "$repo" --body "@dependabot $command"
+  echo "  - #$n"
+done
+'''


### PR DESCRIPTION
From Taiga US [#230](https://tree.taiga.io/project/juanmacvega-booking-service/us/230) — *Automate Dependabot pull request merges*.

## What this does

Adds `dependabot-auto-merge.yml`, triggered via `workflow_run` on the **CI/CD Pipeline** so it runs in the trusted default-branch context with secrets available (Dependabot PRs get neither secrets nor a write token on `pull_request`). Three gated jobs:

- **guard** — proceeds only on CI success, Dependabot author/actor, and a same-repo (non-fork) `dependabot/*` head; re-verifies the PR author via the API.
- **analyse** — runs the Claude Code CLI (`claude-sonnet-5`, read-only `Read,Grep,Glob` tools) over the diff, posts findings as a PR comment, and is fail-safe (any error / missing verdict ⇒ FAIL ⇒ no merge).
- **merge** — only when the verdict is `PASS`: mints a scoped GitHub App token from the branch-restricted `dependabot-merge` environment, approves, and squash-merges.

## Supply-chain hardening (both workflows)

- Every action **pinned by commit SHA**.
- `step-security/harden-runner` on every job — `block` + minimal allowlist on the GitHub-API-only jobs (`guard`, `merge`), `audit` elsewhere pending endpoint discovery.
- Claude Code CLI **pinned to an exact version**, installed in a secret-free step.

## Required repo setup before this is functional

- [ ] GitHub App (least privilege: `contents:write`, `pull_requests:write`), installed on this repo, added to the `master` ruleset **bypass list**.
- [ ] `dependabot-merge` **environment** with deployment branches restricted to `master`; store `MERGE_APP_ID` + `MERGE_APP_PRIVATE_KEY` there.
- [ ] `CLAUDE_CODE_OAUTH_TOKEN` repo Actions secret.
- [ ] Enable "Allow GitHub Actions to create and approve pull requests".

## Follow-up

After the first CI run and first Dependabot analysis, lift the observed endpoints from the harden-runner insights into `allowed-endpoints:` and switch the `audit` jobs to `block`.

Taiga-US: #230
Taiga-URL: https://tree.taiga.io/project/juanmacvega-booking-service/us/230

🤖 Generated with [Claude Code](https://claude.com/claude-code)