### PR TITLE
ci: review every PR change with Claude, codify the finding triage loop

### DIFF
--- a/.claude/commands/develop-story-e2e.md
+++ b/.claude/commands/develop-story-e2e.md
@@ -88,7 +88,7 @@ a summary (not full logs). It stays within the module the plan scoped and **neve
 
 ---
 
-## Step 6 — Parallel review of the implementation
+## Step 6 — Parallel review, then the finding triage loop
 
 With the tests green, validate the code from three angles. **Dispatch all three reviewers in a
 single message so they run in parallel** — each against the **plan** and the acceptance criteria,
@@ -98,12 +98,36 @@ each on the model set in its own agent file (`.claude/agents/`):
 - `architecture-reviewer` — does it comply with the ADRs / CLAUDE.md rules?
 - `security-reviewer` — does it enforce the security the plan required, and is it free of new flaws?
 
-Each returns ranked findings against the current working-tree diff. Consolidate them (drop
-duplicates, order by severity).
+Instruct each reviewer to trace every externally-supplied field from the boundary to its first
+real use — **including into unchanged code** — a defect can be an absence in the diff (a missing
+validation, a missing handler) whose blast radius lives outside it.
 
-**Stop. Present the consolidated review to the user.** If findings warrant changes, return to
-Step 5b (fix under green) and re-run the review. Proceed only once the reviews are clean or the user
-accepts the findings.
+Each returns ranked findings against the current working-tree diff. Consolidate them (drop
+duplicates, order by severity), then run every finding through the triage loop below.
+
+### Finding triage loop (generic — used by any flow that reviews story work)
+
+Findings can come from the Step 6 subagents, from the **GitHub Claude review workflow** that runs
+on every opened PR (fetch its output with `gh api` — issue comments, review bodies, and inline
+review comments; keep a per-PR list of handled comment ids so nothing is triaged twice), or from
+any other reviewer. Every finding gets the same treatment:
+
+- **Valid** — it reproduces as a failing test, is within the story's scope, and fixing it violates
+  no ADR and needs no missing prerequisite. Fix it test-first: red test capturing the failure,
+  minimal fix under green (Step 5b), module architecture test, `mvn spotless:apply`. If the
+  story's commits are already pushed to a PR, add a **follow-up commit** carrying the story's
+  Taiga trailers — never amend or force-push published history.
+- **Invalid** — not reproducible, out of the story's scope (suggest a gap/backlog story instead),
+  or fixable only by violating an ADR or the Hard Constraints (e.g. speculative error handling).
+  Record the finding and the rejection rationale in the triage log; the code does not change.
+
+After fixes, re-run the review — re-dispatch the subagents on the updated diff, or, for PR
+findings, push and wait for the PR workflow's fresh review — until a pass yields **no new valid
+findings**. Cap at **2 fix rounds**; anything still open goes to the user as an explicit open
+question, never silently dropped.
+
+**Stop. Present the triage log — findings fixed and findings rejected with their rationale — to
+the user.** Proceed only once the loop is clean or the user rules on the leftovers.
 
 ---
 

--- a/.claude/commands/parallel-stories.md
+++ b/.claude/commands/parallel-stories.md
@@ -107,19 +107,42 @@ Resume each worker via SendMessage:
 
 ---
 
-## Step 5 — Checkpoint 2: final review and PRs (batched)
+## Step 5 — Checkpoint 2: review, triage-and-fix loop, then PRs (batched)
 
-When a worker finishes, review its worktree diff — dispatch `architecture-reviewer` and
-`semantics-reviewer` in parallel, pointed at the worktree path, each with the story's acceptance
-criteria. Consolidate findings.
+When a worker finishes, review its worktree diff — dispatch `architecture-reviewer`,
+`semantics-reviewer`, and `security-reviewer` in parallel, pointed at the worktree path, each with
+the story's acceptance criteria. Instruct each reviewer to trace every externally-supplied field
+from the boundary to its first real use — **including into unchanged code** — a defect can be an
+absence in the diff (a missing validation, a missing handler) whose blast radius lives outside it.
 
-**Stop. Present each story's result — diff summary, green tests, architecture check, review
-findings — and wait for a per-story verdict.**
+**Triage-and-fix loop — findings are resolved before the user sees the story.** Run every finding
+through the **finding triage loop defined in `/develop-story-e2e` Step 6** (the generic
+valid/invalid rules, red-test-first fixes, 2-round cap, and triage log live there). The only
+parallel-run specifics: valid fixes are executed by the **story's worker in its worktree**, and
+fixes land in the story's commit while it is still unpublished, or as a follow-up commit once
+pushed.
+
+**Stop. Present each story's result — diff summary, green tests, architecture check, and the
+triage log (findings fixed / findings rejected and why) — and wait for a per-story verdict.** The
+user reviews already-valid work: red tests written during triage are validated here,
+retrospectively, instead of blocking mid-loop (explicitly delegated by the user).
 
 - **Approved** → push the branch, open a PR into `master` with `gh` (story summary + Taiga
   trailers in the body — use the story **permalink**, not just the bare ref, whenever the backend
   returns one; a bare `#NNN` renders as a misleading GitHub link), and add the PR link to the
-  story via `/manage-backlog-item`.
+  story via `/manage-backlog-item`. Then run the **PR review-comment loop** below — a Claude
+  review workflow runs on every opened PR, and its findings must be triaged before the PR is
+  handed to the user.
+
+### PR review-comment loop (after each PR is opened or pushed to)
+
+The repo's GitHub workflow has Claude review every PR on open, and re-review on later pushes. For
+each open PR of this run: wait for the review workflow run to complete (`gh run list` /
+`gh pr checks`), fetch the bot's findings, and run them through the **finding triage loop in
+`/develop-story-e2e` Step 6** (which covers how to fetch PR comments, follow-up commits, re-review
+after a push, and the 2-round cap). The goal: by the time the user looks at a PR, every bot
+finding is either fixed on the branch or answered in the triage log — no manual `@claude` triggers
+needed.
 - **Rejected with feedback** → SendMessage the feedback to the same worker in the same worktree; it
   revises under green and returns to this checkpoint. The worktree is **kept** — it is deleted only
   on merge or explicit abandon.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,7 +10,7 @@ on:
   issues:
     types: [opened]
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 jobs:
   # Interactive: respond to @claude mentions. The action itself refuses to act for a
@@ -47,15 +47,19 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-sonnet-5"
 
-  # Automatic review when a PR is opened. Skips forks and Dependabot, which do not receive the
-  # secret on `pull_request` (and Dependabot PRs are already reviewed by the auto-merge
-  # workflow).
+  # Automatic review when a PR is opened or updated. Skips forks and Dependabot, which do not
+  # receive the secret on `pull_request` (and Dependabot PRs are already reviewed by the
+  # auto-merge workflow). Only the latest push per PR is reviewed: a newer push cancels the
+  # in-flight review of the now-stale diff.
   review:
-    name: Review on open
+    name: Review PR changes
     if: >
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'dependabot[bot]'
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -82,4 +86,7 @@ jobs:
             Review the pull request diff. Focus on correctness bugs, security issues, and
             compliance with the Architecture Decision Records in docs/design-decisions.md.
             Leave inline review comments on specific lines where warranted, and a short summary.
+            If you have reviewed this PR before (look for previous claude[bot] comments), check
+            whether each earlier finding was addressed by the new commits and say so explicitly,
+            reviewing only the changed code in depth rather than restating the whole diff.
             Do not approve or merge; this review is advisory.

--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,17 @@ A Java 25 booking engine project using Maven multi-module architecture, Spring B
 
 ## Recent Changes (Last 2 Weeks)
 
+### Latest Commit: ci: review every PR change with Claude, codify the finding triage loop
+**Date:** Jul 16, 2026
+**Commit:** 3d2bc07
+
+**Changed files:**
+- .claude/commands/develop-story-e2e.md
+- .claude/commands/parallel-stories.md
+- .github/workflows/claude.yml
+
+---
+
 ### Latest Commit: Add claude.yaml to allow Claude Code to review PRs
 **Date:** Jul 16, 2026
 **Commit:** cee9437


### PR DESCRIPTION
## Summary

- `.github/workflows/claude.yml`: add `synchronize` to the `pull_request` triggers so the advisory Claude review runs on **every push** to a PR, not just open/reopen; add per-PR concurrency with `cancel-in-progress` so only the latest diff is reviewed; make the review prompt re-review-aware (it checks its own earlier comments and states whether each finding was addressed).
- `.claude/commands/develop-story-e2e.md`: Step 6 now defines the generic **finding triage loop** — every reviewer finding (subagent or PR-bot) is triaged valid/invalid, valid ones fixed test-first (follow-up commits once published, never force-push), 2-round cap, triage log presented to the user.
- `.claude/commands/parallel-stories.md`: references the generic loop instead of defining its own; adds the post-PR review-comment step.

The review stays **advisory** (comment, not a required status check) — branch protection still requires a human review to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)