### PR TITLE
ci: let the automatic PR review actually post its comment

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -64,6 +64,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Harden the runner
@@ -77,10 +78,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      # track_progress makes the action post/update a PR comment on pull_request events;
+      # without it the agent has no comment tool and the review completes invisibly.
       - name: Review the pull request
         uses: anthropics/claude-code-action@12531344451323133b0493233c759991ac61da12 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
           claude_args: "--model claude-sonnet-5"
           prompt: |
             Review the pull request diff. Focus on correctness bugs, security issues, and

--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,15 @@ A Java 25 booking engine project using Maven multi-module architecture, Spring B
 
 ## Recent Changes (Last 2 Weeks)
 
+### Latest Commit: ci: let the automatic PR review actually post its comment
+**Date:** Jul 16, 2026
+**Commit:** b4bf9c6
+
+**Changed files:**
+- .github/workflows/claude.yml
+
+---
+
 ### Latest Commit: ci: review every PR change with Claude, codify the finding triage loop
 **Date:** Jul 16, 2026
 **Commit:** 3d2bc07


### PR DESCRIPTION
## Summary

The `pull_request`-event review job (review-on-open, and since #65 review-on-every-push) has been running but **silently discarding its review**:

- Without `track_progress: true`, claude-code-action gives the agent no comment tool on automation events — the club synchronize run finished "successfully" with **12 permission denials** and posted nothing; PR #65's own review-on-open also posted nothing. Every visible review so far came from manual `@claude` mentions.
- The job also lacked `issues: write`, needed to create issue comments on PRs.

With this change the automatic review posts and updates a tracking comment per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)