### PR TITLE
fix(logging): use a logback encoder instead of a deprecated layout

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,16 @@ A Java 25 booking engine project using Maven multi-module architecture, Spring B
 
 ## Recent Changes (Last 2 Weeks)
 
+### Latest Commit: fix(logging): use a logback encoder instead of a deprecated layout
+**Date:** Jul 19, 2026
+**Commit:** daa6dc9
+
+**Changed files:**
+- impl/src/main/resources/logback.xml
+- test/src/test/resources/logback-test.xml
+
+---
+
 ### Latest Commit: fix(ci): enforce HTTPS on tool downloads (Sonar S6506)
 **Date:** Jul 18, 2026
 **Commit:** 5473de6

--- a/impl/src/main/resources/logback.xml
+++ b/impl/src/main/resources/logback.xml
@@ -2,11 +2,11 @@
 <configuration>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>
+    <encoder>
+      <pattern>
         %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
-      </Pattern>
-    </layout>
+      </pattern>
+    </encoder>
   </appender>
 
   <root level="info">

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -2,11 +2,11 @@
 <configuration>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>
+    <encoder>
+      <pattern>
         %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
-      </Pattern>
-    </layout>
+      </pattern>
+    </encoder>
   </appender>
 
   <root level="debug">


### PR DESCRIPTION
From Taiga US [#240](https://tree.taiga.io/project/juanmacvega-booking-service/us/240), under epic #231.

`impl/src/main/resources/logback.xml` and `test/src/test/resources/logback-test.xml` declared a `<layout>` directly inside the `ConsoleAppender`, which logback deprecates and warns about on every logging-context init:

```
This appender no longer admits a layout as a sub-component, set an encoder instead.
```

That warning repeated dozens of times per test run in the CI logs. Wrapping the pattern in an `<encoder>` (the modern idiom) silences it with no change to the log output format.

Verified locally: `mvn -pl impl test` → 0 layout warnings, 375 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)