### PR TITLE
fix(ci): drop explicit checkout ref to clear Sonar S7631 on master

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -112,16 +112,10 @@ jobs:
             downloads.claude.ai:443
             api.anthropic.com:443
 
-      # Deliberately check out the DEFAULT BRANCH, not the PR head. This job runs in the
-      # privileged workflow_run context (secrets + write token), so checking out the PR's code
-      # and letting a tool act on it would let a malicious change run with the repo's privileges.
-      # The analysis only needs (a) how the project currently uses the dependency — which is
-      # master, since a Dependabot PR bumps a version and does not touch src — and (b) the change
-      # itself, which is fetched below as an API-delivered diff, not executed.
+      # No ref: on workflow_run, checkout defaults to the default branch, never the PR head, so
+      # this privileged job never runs untrusted PR code. Do not add a ref.
       - name: Checkout the default branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.repository.default_branch }}
 
       - name: Install Claude Code CLI
         # Download the pinned native binary from the signed release bucket and verify it before

--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,15 @@ A Java 25 booking engine project using Maven multi-module architecture, Spring B
 
 ## Recent Changes (Last 2 Weeks)
 
+### Latest Commit: fix(ci): drop explicit checkout ref to clear Sonar S7631 on master
+**Date:** Jul 19, 2026
+**Commit:** d9d213d
+
+**Changed files:**
+- .github/workflows/dependabot-auto-merge.yml
+
+---
+
 ### Latest Commit: fix(logging): use a logback encoder instead of a deprecated layout
 **Date:** Jul 19, 2026
 **Commit:** daa6dc9


### PR DESCRIPTION
From Taiga US [#237](https://tree.taiga.io/project/juanmacvega-booking-service/us/237).

## Why master's gate went red after #70

PR #70's auto-merge hardening fixed S7631 by checking out `github.event.repository.default_branch` instead of the PR head SHA. That ref *is* trusted — but S7631 flags **any explicit `ref:`** on a checkout inside a privileged `workflow_run` job, because the heuristic can't evaluate that the ref is safe. On PR #70 the rule was suppressed in its changed-lines scope, but master's full re-analysis fired it, so `new_security_rating` went to C and the gate turned red.

## Fix

Remove the explicit `ref:`. For a `workflow_run` event, `actions/checkout` defaults to the repository's default branch (`github.ref` points there) — **never** the PR head. So the checkout is exactly as trusted, without the flagged explicit-ref pattern. This is GitHub's own documented safe pattern for privileged workflows. A comment warns against re-adding a `ref:`.

Verified: actionlint passes. Final confirmation is this PR's Sonar run (expected: 0 vulnerabilities, gate green) and master going green on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)