### PR TITLE
ci: fail the build when the SonarCloud quality gate is red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,9 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn sonar:sonar
+        # qualitygate.wait polls SonarCloud after submitting and fails the step if the gate is red,
+        # so a regression breaks the build instead of only showing on the PR decoration.
+        run: mvn sonar:sonar -Dsonar.qualitygate.wait=true
 
   code-quality:
     name: Code Quality Checks

--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,15 @@ A Java 25 booking engine project using Maven multi-module architecture, Spring B
 
 ## Recent Changes (Last 2 Weeks)
 
+### Latest Commit: ci: fail the build when the SonarCloud quality gate is red
+**Date:** Jul 19, 2026
+**Commit:** 4f2e3fb
+
+**Changed files:**
+- .github/workflows/ci.yml
+
+---
+
 ### Latest Commit: fix(ci): drop explicit checkout ref to clear Sonar S7631 on master
 **Date:** Jul 19, 2026
 **Commit:** d9d213d


### PR DESCRIPTION
From Taiga US [#237](https://tree.taiga.io/project/juanmacvega-booking-service/us/237) — the final acceptance criterion, deferred until the gate was green on master.

Until now `mvn sonar:sonar` submitted the analysis and returned immediately, so a failing quality gate only appeared on the SonarCloud PR decoration and never failed CI (as we saw when the S6506/S7631 findings went red while every job stayed green). Adding `-Dsonar.qualitygate.wait=true` makes the Sonar step poll for the computed gate and exit non-zero when it's red, so a regression breaks the build.

Enabled now that master's gate is **OK** with 0 vulnerabilities (after #70 and #72). This PR's own run is the first to exercise it — it should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)