### PR TITLE
fix(ci): create the bin directory before installing the Claude CLI

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -145,6 +145,8 @@ jobs:
           dl -o claude "$base/linux-x64/claude"
           echo "${expected}  claude" | sha256sum -c -
 
+          # The directory does not exist on a clean runner image and install will not create it.
+          mkdir -p "$HOME/.local/bin"
           install -m 0755 claude "$HOME/.local/bin/claude"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,15 @@ A Java 25 booking engine project using Maven multi-module architecture, Spring B
 
 ## Recent Changes (Last 2 Weeks)
 
+### Latest Commit: fix(ci): create the bin directory before installing the Claude CLI
+**Date:** Jul 23, 2026
+**Commit:** 3485488
+
+**Changed files:**
+- .github/workflows/dependabot-auto-merge.yml
+
+---
+
 ### Latest Commit: ci: fail the build when the SonarCloud quality gate is red
 **Date:** Jul 19, 2026
 **Commit:** 4f2e3fb


### PR DESCRIPTION
From Taiga US [#241](https://tree.taiga.io/project/juanmacvega-booking-service/us/241).

## Problem

The verified-binary install added by US #237 ends with:

```bash
install -m 0755 claude "$HOME/.local/bin/claude"
```

`/home/runner/.local/bin` does not exist on the `ubuntu-latest` image, and `install` does not create missing parents. Run #94 — the first execution to get past the `guard` job — failed there:

```
gpg: Good signature from "Anthropic Claude Code Release Signing <security@anthropic.com>"
claude: OK
install: cannot create regular file '/home/runner/.local/bin/claude': No such file or directory
```

Both the GPG manifest verification and the SHA256 comparison had already succeeded — only the placement failed, so the analysis never ran. The fail-safe behaved correctly: no verdict was set, the comment step defaulted to FAIL, and `merge` was skipped. Nothing was mis-merged.

The bug was latent since `dad75b6` (18 Jul); runs #88–#93 all stopped at the guard pre-filters, so #94 was the first execution of that code path.

## Fix

`mkdir -p "$HOME/.local/bin"` before the install. Chosen over `install -D` because `-D` means an unrelated thing on BSD `install`, so the non-portable form fails with a confusing usage error rather than a clean one. `mkdir -p` is POSIX and idempotent under `set -euo pipefail`.

## Verification

- `ubuntu:24.04` container: old form reproduces the exact failure; new form exits 0, creates the path, and is idempotent on a second run under `set -e`.
- macOS/BSD `install`: same form works.
- `pre-commit run actionlint --all-files`: passed.

The remaining acceptance criterion — a real `analyse` job going green — can only be confirmed by the next Dependabot PR that reaches it.

## Note on merging

This touches `.github/workflows/**`, so the auto-merge path deliberately excludes it: the merge App is not granted `workflows` write. Manual merge required by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)