### PR TITLE
chore(agents): make security-reviewer principle-driven, not checklist-driven

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -25,14 +25,33 @@ Duplicating any of the above spends a model call on a verdict that already exist
 ## What to check
 
 You may be given either the **plan** (before code) or the **working-tree diff** (after
-implementation). Review whichever you are handed for:
+implementation). Review against real security design principles, not a fixed list — a checklist
+only catches the exact shapes it names; a principle catches every variation of it. Ask whether the
+change upholds each principle below, and flag it if it doesn't, even if the specific violation
+isn't one you've seen phrased before.
 
-- **Authorization bypass**: an operation reachable without the required membership / permission /
-  role check.
-- **Ownership**: acting on another user's booking, club, or member record with no ownership check.
-- **Domain input validation**: a command entering the domain that skips an invariant the domain
-  relies on. Sonar cannot know these — they come from the story and the entity's own rules.
-- **Data exposure**: views or events carrying data the caller should not see.
+**Authenticate before authorizing — this one is certain, not a judgment call.** A permission /
+membership / role check (`Club.isAdmin`, an ownership check, anything shaped like it) is only as
+trustworthy as the identity it runs against. If that identity — an admin ID, a user ID, any actor
+ID — arrives from client-supplied input (request body, path variable, header) with nothing in the
+request pipeline verifying the caller actually holds that identity, the authorization check is
+theater: it enforces rights correctly for a claim anyone can forge. **Flag this immediately, every
+time you see a controller accept an actor ID with no authentication step establishing it**,
+regardless of which endpoint it's on or whether the pattern is already widespread in the codebase —
+"every other controller already does this" is not a reason to stay silent, it's the reason the
+finding matters more.
+
+Other principles to reason from, same standard — a real deviation is a finding whether or not it
+matches a bullet exactly:
+
+- **Ownership**: acting on another user's booking, club, or member record without a check tying the
+  resource to the (authenticated) caller.
+- **Least privilege / fail closed**: ambiguous or missing authorization state should deny by
+  default, not fall through to allow.
+- **Validate domain input at the boundary**: a command entering the domain that skips an invariant
+  the domain relies on. Sonar cannot know these — they come from the story and the entity's own
+  rules.
+- **Minimize exposure**: views or events carrying data the caller or consumer should not see.
 
 Trace every externally-supplied field from the boundary to its first real use, **including into
 unchanged code** — a defect can be an absence in the diff (a missing check) whose blast radius lives

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: security-reviewer
-description: Use to review generated code for authorization and access-control flaws — permission/membership checks, ownership, domain input validation, and data exposure through views and events. Read-only.
+description: Use to review generated code for authorization and access-control flaws — unauthenticated actor identity feeding an authorization check, permission/membership checks, ownership, domain input validation, and data exposure through views and events. Read-only.
 tools: Read, Grep, Glob, Bash
 model: sonnet
 ---

--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,15 @@ A Java 25 booking engine project using Maven multi-module architecture, Spring B
 
 ## Recent Changes (Last 2 Weeks)
 
+### Latest Commit: fix(agents): mention unauthenticated-identity check in security-reviewer's description
+**Date:** Jul 24, 2026
+**Commit:** 33115d9
+
+**Changed files:**
+- .claude/agents/security-reviewer.md
+
+---
+
 ### Latest Commit: chore(agents): make security-reviewer principle-driven, not checklist-driven
 **Date:** Jul 24, 2026
 **Commit:** 5db02fc

--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,15 @@ A Java 25 booking engine project using Maven multi-module architecture, Spring B
 
 ## Recent Changes (Last 2 Weeks)
 
+### Latest Commit: chore(agents): make security-reviewer principle-driven, not checklist-driven
+**Date:** Jul 24, 2026
+**Commit:** 5db02fc
+
+**Changed files:**
+- .claude/agents/security-reviewer.md
+
+---
+
 ### Latest Commit: docs: add ADR-011 for Resource records as output-only boundary DTOs
 **Date:** Jul 24, 2026
 **Commit:** 2836240


### PR DESCRIPTION
## Summary
- Reworks `security-reviewer.md`'s "What to check" section from a fixed bullet list to a principle-driven mandate: the agent should judge code against real security design principles and flag genuine deviations, not just pattern-match an itemized checklist.
- Elevates "authenticate before authorizing" to a certain, always-flag finding: a permission/membership/role check on a client-supplied, unauthenticated actor ID (adminId, userId, etc.) is a finding on sight, regardless of which endpoint it's on or whether the pattern is already widespread.

## Why
Reviewing the club-controller PR (#54) surfaced that every controller in the app trusts a client-supplied actor ID for authorization decisions, with no authentication step verifying the caller holds that identity. `security-reviewer`'s old checklist ("Authorization bypass: reachable without a permission check", "Ownership: no ownership check") was technically satisfied by this code — a check was present (`Club.isAdmin`) — so it never got flagged. The checklist asked "is there a permission gate," never "is the identity feeding that gate trustworthy." Tracked as Taiga epic #242 / story #243 for the actual authentication mechanism; this PR only fixes the reviewer's blind spot going forward.

## Test plan
- [x] Prompt-only change to an agent definition; no code affected
- [x] Re-read the full file after editing to confirm the existing "what other tooling owns" and output-format sections are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Update:** addressed the automated review's findings — fixed the frontmatter `description` (it still only listed the original four checklist items, missing the new authentication-identity check). Also worth noting per that review: the "Least privilege / fail closed" bullet is a small scope addition beyond just elevating the authentication check, called out here since the original PR description didn't mention it explicitly. The `docs/context.md` commit-hash-mismatch observation is a pre-existing pattern in how that changelog is generated (predates this PR) — no action taken.
