### PR TITLE
fix(auction): pin the clock before the auction is created in finish-auction scenarios

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,15 @@ A Java 25 booking engine project using Maven multi-module architecture, Spring B
 
 ## Recent Changes (Last 2 Weeks)
 
+### Latest Commit: fix(auction): pin the clock before the auction is created in finish-auction scenarios
+**Date:** Jul 26, 2026
+**Commit:** 9700c36
+
+**Changed files:**
+- impl/src/test/resources/features/auction/finish_auction_use_case.feature
+
+---
+
 ### Latest Commit: fix(agents): mention unauthenticated-identity check in security-reviewer's description
 **Date:** Jul 24, 2026
 **Commit:** 33115d9

--- a/impl/src/test/resources/features/auction/finish_auction_use_case.feature
+++ b/impl/src/test/resources/features/auction/finish_auction_use_case.feature
@@ -6,6 +6,7 @@ Feature: As a user, I want to know the result of an auction I bid for
     And a building is created
     And a room is created
     And a slot is created
+    And current time is 08:00
 
   Scenario: As a user, I shouldn't win an auction if there is someone with a better criteria when the auction is configured
   to make the winner the person with less bookings within a period of time


### PR DESCRIPTION
Fixes the `impl` suite being red for part of every day.

Taiga US #245 — https://tree.taiga.io/project/juanmacvega-booking-service/us/245

## The bug

Two scenarios in `finish_auction_use_case.feature` fail with `AuctionFinishedException: Auction 1 for slot 1 is already finished`, surfacing as 4 errors because both `CucumberTest` and `UseCaseCTest` run the same features.

It is **not flaky** — it is fully determined by the wall clock. It fails on every run before 07:55 UTC and passes on every run after.

`AuctionFactory.createFrom` stamps the auction's start with `ZonedDateTime.now(clock)`. The feature created the auction while the stub clock still delegated to `Clock.systemUTC()`, and only then pinned the clock to a hardcoded `08:05`. Since `MockConfig` seeds `ClockStub` from `Clock.systemUTC()`, that `08:05` is 08:05 **UTC**, not local time.

Observed at 08:29 CEST (06:29 UTC): the auction opened at 06:29 and closed at 06:39, the clock was then pinned to 08:05 — past the close — and the first bid threw. Run the same suite at 20:28 UTC and it passes, which is why it was green yesterday evening and red this morning.

## The fix

Pin the clock in the `Background`, before any auction exists, so its start time comes from the pinned clock rather than the real one:

```gherkin
     And a slot is created
+    And current time is 08:00
```

The auction now always opens at 08:00 UTC and closes at 08:10, with the bids at 08:00/08:05/08:06 inside the window, independent of when the suite runs.

This restores consistency with the sibling auction features, which were already correct and therefore unaffected: `add_bidder_to_auction_use_case.feature` pins the clock before creating the auction in every scenario, and `schedule_finish_auction_use_case.feature` pins it in its `Background`.

## Production impact

None. `Auction.isOpen` only checks `now.isBefore(endTime)`, which is correct for a forward-moving clock. Its inline comment — "Now cannot be before start time as start time is always now at creation time" — documents an assumption that only the test's clock rewind could break.

## Verification

- Reproduced on clean `origin/master` before the change.
- Full `impl` suite green after it: 375 tests, 0 failures, 0 errors.
- Note the pre-commit Maven hook skips this commit — it triggers on Java files only, and this is a `.feature` change — so the suite was run manually.

## Why this is worth merging first

The pre-commit hook runs the full Maven suite, so this blocks commits on every branch, including the four in-flight controller PRs (#52-#55). Those rebase from master once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)