### PR TITLE
chore(ci): mint the merge token with client-id, not the deprecated app-id

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -299,7 +299,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          client-id: ${{ secrets.MERGE_APP_CLIENT_ID }}
           private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}
 
       - name: Squash-merge the Dependabot PR

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -292,10 +292,14 @@ jobs:
             api.github.com:443
 
       - name: Mint GitHub App token
+        # `client-id`, not the deprecated `app-id`: they are different values --
+        # the client id is the Iv23li... string on the App's settings page, not
+        # the numeric App ID. The numeric one is still what the master ruleset's
+        # bypass entry matches on, so the two are not interchangeable anywhere.
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.MERGE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}
 
       - name: Squash-merge the Dependabot PR

--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,15 @@ A Java 25 booking engine project using Maven multi-module architecture, Spring B
 
 ## Recent Changes (Last 2 Weeks)
 
+### Latest Commit: chore(ci): mint the merge token with client-id, not the deprecated app-id
+**Date:** Jul 26, 2026
+**Commit:** bfd3b8c
+
+**Changed files:**
+- .github/workflows/dependabot-auto-merge.yml
+
+---
+
 ### Latest Commit: fix(auction): pin the clock before the auction is created in finish-auction scenarios
 **Date:** Jul 26, 2026
 **Commit:** 9700c36

--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,15 @@ A Java 25 booking engine project using Maven multi-module architecture, Spring B
 
 ## Recent Changes (Last 2 Weeks)
 
+### Latest Commit: chore(ci): name the merge App client id secret MERGE_APP_CLIENT_ID
+**Date:** Jul 26, 2026
+**Commit:** f02b26e
+
+**Changed files:**
+- .github/workflows/dependabot-auto-merge.yml
+
+---
+
 ### Latest Commit: chore(ci): mint the merge token with client-id, not the deprecated app-id
 **Date:** Jul 26, 2026
 **Commit:** bfd3b8c


### PR DESCRIPTION
The Dependabot merge job warns:

> Input 'app-id' has been deprecated with message: Use 'client-id' instead.

`actions/create-github-app-token` still accepts both, so this is warning-only and nothing is broken — but the deprecated input will not stay forever. Same change just made in taiga-mcp, which uses the same App.

They are different values, not two names for one. `client-id` wants the `Iv23li…` string from the App's settings page; the numeric App ID is what the `master` ruleset's bypass entry matches on (`actor_id`). Swapping one for the other in either place silently breaks the merge with no useful error, so the comment now says which is which.

The client id reads from `MERGE_APP_CLIENT_ID`, matching its `MERGE_APP_PRIVATE_KEY` sibling. It was briefly added to the environment as `RELEASE_APP_CLIENT_ID` — copied from taiga-mcp — and the second commit here moves to the correctly named secret.

`RELEASE_APP_CLIENT_ID` and `MERGE_APP_ID` can both be deleted from the `dependabot-merge` environment once this lands.