### PR TITLE
ci(dependabot): ask Dependabot to rebase PRs that fall behind master

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,8 +17,8 @@ permissions:
   contents: read
 
 # Serialize entire runs: while one PR is being analysed and merged, others wait. Once the
-# winner merges, the losers are behind master and the guard below skips them until Dependabot
-# rebases and re-triggers them — avoiding redundant analysis and untested merges.
+# winner merges, the losers are behind master and the guard below asks Dependabot to rebase them,
+# which re-triggers CI and this workflow — avoiding redundant analysis and untested merges.
 concurrency:
   group: dependabot-auto-merge
   cancel-in-progress: false
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
     # Cheap pre-filters only: run on a successful CI completion for a same-repo dependabot/*
     # branch. The trust decision — that the PR is genuinely authored by Dependabot — is NOT made
     # here: actor/triggering_actor identify who triggered the run, not who authored the PR, and
@@ -74,13 +74,30 @@ jobs:
             exit 0
           fi
 
-          # Skip a PR that is behind master: it will be rebased and re-triggered, so analysing
-          # or merging it now is wasted work and would merge a combination CI never tested.
+          # A PR behind master must not be analysed or merged: that would merge a combination CI
+          # never tested. Ask Dependabot to rebase rather than only skipping — Dependabot rebases
+          # on its own just for conflicts or a changed manifest, so a PR that is merely behind
+          # (a github-actions update while master moves on Java code) would otherwise sit here
+          # forever, never pushed, never re-triggering CI, never re-entering this workflow.
           head=$(gh pr view "$pr" --repo "${{ github.repository }}" \
             --json headRefOid --jq '.headRefOid')
           behind=$(gh api "repos/${{ github.repository }}/compare/master...$head" --jq '.behind_by')
           if [ "${behind:-0}" -gt 0 ]; then
-            echo "PR #$pr is $behind commit(s) behind master; skipping until it is rebased."
+            echo "PR #$pr is $behind commit(s) behind master; asking Dependabot to rebase it."
+
+            # One ask per head SHA. Several CI runs can complete on the same commit, and each
+            # re-enters this guard; the marker keeps that from posting duplicate commands. Once
+            # Dependabot rebases, the head changes and a fresh ask is allowed.
+            marker="<!-- auto-merge:rebase-requested:$head -->"
+            asked=$(gh pr view "$pr" --repo "${{ github.repository }}" \
+              --json comments --jq "[.comments[] | select(.body | contains(\"$marker\"))] | length")
+            if [ "${asked:-0}" -gt 0 ]; then
+              echo "Rebase already requested for $head; not asking again."
+            else
+              gh pr comment "$pr" --repo "${{ github.repository }}" \
+                --body "$marker"$'\n'"@dependabot rebase"
+            fi
+
             echo "number=" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## Problem

The auto-merge guard skipped any Dependabot PR that was behind master, on the assumption — stated in its own comment — that Dependabot would rebase it and re-trigger CI.

That assumption doesn't hold. Dependabot rebases on **conflicts** or a **changed manifest**. A PR that is *merely* behind gets neither: a `github-actions` group update sits untouched while master moves on Java code. The branch is never pushed, CI never re-runs, no `workflow_run` fires, and the guard never re-evaluates. The PR stays open indefinitely.

Observed live on #82: its auto-merge run (`30253263555`) logged

```
PR #82 is 1 commit(s) behind master; skipping until it is rebased.
```

and nothing has moved it since.

## Change

The guard now posts `@dependabot rebase` on such a PR before skipping the `analyse` and `merge` jobs, making the skip self-healing.

The comment carries an HTML marker keyed to the PR's **head SHA**. That suppresses duplicate commands when several CI runs complete on the same commit — a re-run, or the concurrency-group cancellation seen on #83 (`30253257485`) — while every rebase changes the head and is free to ask again. Repeated rebase cycles are supported; only repeated asks for an *unchanged* head are not.

The guard job widens from `pull-requests: read` to `write`, which it needs in order to comment. The merge job's separate GitHub App token is untouched.

## Notes

- Behaviour when a PR is up to date is unchanged.
- `workflow_run` loads the workflow from the default branch, so this only takes effect after it merges. #82 will still need a manual `@dependabot rebase` to unstick.
- Not addressed here: a merge queue, or setting `rebase-strategy` in `dependabot.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)