### PR TITLE
docs: record component user flows and make flow documentation a rule

### DIFF
--- a/.claude/commands/develop-controller.md
+++ b/.claude/commands/develop-controller.md
@@ -88,3 +88,13 @@ Run, in the `controller` module:
 - `mvn spotless:apply` before presenting.
 
 **Stop. Present the passing tests and the architecture check for final review.**
+
+---
+
+## Step 4 — Update the flow documentation
+
+A controller makes a command user-reachable; a listener wires a reaction. If that
+changes a component's place in the user-visible flow — or exposes that the documented
+flow was wrong or incomplete — update the affected `COMPONENT.md` files in the same
+change, following the *Component flow documentation* rules in CLAUDE.md. Gaps
+discovered become stories via `/manage-backlog-item`, never documentation notes.

--- a/.claude/commands/develop-story-e2e.md
+++ b/.claude/commands/develop-story-e2e.md
@@ -131,10 +131,14 @@ the user.** Proceed only once the loop is clean or the user rules on the leftove
 
 ---
 
-## Step 7 — Update documentation
+## Step 7 — Update the flow documentation
 
-Apply the plan's `COMPONENT.md` additions for the component(s) touched, so the docs match the new
-behaviour.
+Apply the plan's `COMPONENT.md` additions for the component(s) touched, following the
+*Component flow documentation* rules in CLAUDE.md: design level, user-facing commands vs
+reactions to events, events published and reacted to — never class names, never event
+consumers, never gaps. Any change to a user-visible flow, and any flow discovery made
+during the story, lands here in the same change; gaps found become stories via
+`/manage-backlog-item`, attached to the component's epic or a transverse one.
 
 ---
 

--- a/.claude/commands/develop-use-case.md
+++ b/.claude/commands/develop-use-case.md
@@ -73,3 +73,16 @@ Write the domain logic that makes the failing tests pass.
 
 Implement exactly what the tests require. No extra fields, methods, or classes beyond
 what is needed to go green.
+
+---
+
+## Step 5 — Update the flow documentation
+
+If the use case added or altered a user-facing command, a reaction to an event, or an
+event a component publishes, update the `COMPONENT.md` of every component touched —
+following the *Component flow documentation* rules in CLAUDE.md (design level; commands
+vs reactions; publishes / reacts-to; never class names, never consumers, never gaps).
+
+Any gap discovered on the way (an unwired reaction, a missing guard, a missing entry
+point) becomes a story via `/manage-backlog-item`, attached to the component's epic or a
+transverse one — never a note in the documentation.

--- a/.claude/commands/manage-backlog-item.md
+++ b/.claude/commands/manage-backlog-item.md
@@ -57,6 +57,11 @@ caller (e.g. `/start-story`) presents them and the user chooses. Do not pick one
 
 Use when no existing story authorises the work (CLAUDE.md requires every change to map to a story).
 
+Also use it for **flow gaps** discovered while developing or documenting — an unwired
+reaction, a missing guard, a missing entry point. Per CLAUDE.md's component flow
+documentation rules they are recorded as stories, attached to the component's epic or a
+transverse one (e.g. security) — never as notes in `COMPONENT.md`.
+
 ### Step 1 — Draft the story
 Gather the intent from the user, then write it well:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,32 @@ New repository methods follow the signature:
   `computeIfPresent` (see `ClassManagerComponentRepositoryInMemory.execute`). Both forms are
   acceptable; reaching for a lock around a single `put` is not required.
 
+### Component flow documentation (COMPONENT.md)
+
+Every component directory carries a `COMPONENT.md`. Besides invariants, it records the
+component's place in the **user-visible flow**, written at design level — it describes
+what the code *should* do, and it is the entry point for anyone, human or LLM, new to
+the component.
+
+- From the user's point of view: which operations are **user-facing commands** (guarded
+  — prerequisites and refusals) and which are **reactions to events** (unguarded — the
+  guarded command that produced the event already validated everything).
+- The events it **publishes** (what they announce and carry, at design level) and the
+  events it **reacts to**, with the reaction. **Never who consumes its events**: events
+  are asynchronous and decoupled, and consumers change without the publisher knowing.
+  Flows are reconstructed by linking documents — the slot document says reserving
+  publishes a slot-reserved event; the booking document says it reacts to a slot
+  reservation by creating the booking.
+- **Never name classes, methods, files, or endpoints** — those go stale first. Lean on
+  the naming conventions to point at code ("the use case that creates the booking",
+  "the slot-reserved event").
+- **Never document gaps or wiring status.** A discovered gap becomes a story, attached
+  to the component's epic or a transverse one (e.g. security); left in the document it
+  goes stale and misleads future work.
+
+Any change that alters a flow — and any discovery that reveals one — updates the
+affected `COMPONENT.md` files in the same change.
+
 ---
 
 ## Linting and formatting
@@ -208,4 +234,7 @@ Never present code for review that fails `spotless:check`.
   is non-obvious.
 - Do not write production code before the story's tests exist, fail, and have been validated by
   the user.
+- Do not alter or wire a user-visible flow, and do not leave a flow discovery
+  unrecorded: the affected `COMPONENT.md` files update in the same change, and gaps
+  become stories, never documentation.
 - Do not proceed past a checkpoint without explicit approval.

--- a/impl/src/main/java/com/jusoft/bookingengine/component/booking/COMPONENT.md
+++ b/impl/src/main/java/com/jusoft/bookingengine/component/booking/COMPONENT.md
@@ -1,21 +1,31 @@
 # Booking Component
 
-Records a confirmed reservation: a user owns a booking that references a slot.
+Records a confirmed reservation: a booking is the ledger entry proving a user holds a
+slot. A booking is created in reaction to a slot being reserved — never directly by a
+user request.
 
 ## Invariants
-- Only the user who created a booking may cancel it (`WrongBookingUserException`).
+- Only the user who owns a booking may act on it.
 - A booking is immutable after creation — no update operations exist.
-- Booking time is stamped at creation using the system clock.
+- Booking time is stamped at creation from the injected clock.
+
+## User flow
+- **Creating is a reaction, not a command.** When a slot is reserved by a person, this
+  component reacts by creating the booking for that slot and the user who reserved it.
+  The reaction performs no checks of its own: the guarded command that produced the
+  event already validated membership, authorization and slot availability. A
+  reservation made by a class does not produce a personal booking.
+- **Cancelling is the user-facing command.** Its guards live here, with the contested
+  state: only the owner may cancel, and not once the slot has started.
+- **Reading** is a user-facing query over the ledger, restricted to the owner.
 
 ## What this component does NOT own
-- Slot state transitions — those happen in the `slot` component triggered by events.
-- Authorization checks — the caller (use case) is responsible for verifying the user is allowed to book before invoking this component.
+- Slot state — the slot component owns it.
+- Whether a user may take a slot — decided at reservation time. The booking-creation
+  reaction must not re-check authorization.
 
-## Events published
-| Event | When |
-|---|---|
-| `BookingCreatedEvent` | Booking created (carries `bookingId`, `userId`, `slotId`) |
-| `BookingCanceledEvent` | Booking canceled |
-
-## Dependencies
-- `MessagePublisher` — event bus
+## Events
+- **Reacts to:** a slot reserved by a person — creates the booking for that slot and
+  the user who reserved it.
+- **Publishes:** booking created — announces the new booking, the user and the slot;
+  booking canceled — announces the canceled booking and the slot it releases.

--- a/impl/src/main/java/com/jusoft/bookingengine/component/slot/COMPONENT.md
+++ b/impl/src/main/java/com/jusoft/bookingengine/component/slot/COMPONENT.md
@@ -16,6 +16,19 @@ Manages time slots within a room. A slot represents a bookable unit of time.
 
 The internal `SlotState` interface is package-private. The public `api.SlotState` enum is the view representation — `SlotStateFactory` maps between the two.
 
+## User flow — reserving a slot
+
+Reserving a slot is the user-facing booking action.
+
+1. The reserve use case is the guarded entry point. Its prerequisites — the slot is
+   available and open, the user is a member of the club, the user is authorized for the
+   room — each refuse with a distinct notification.
+2. A successful reservation transitions the slot and publishes an event carrying the
+   slot, the user, and the kind of reservation (person or class).
+
+This component also reacts to a booking cancellation by making the slot available
+again.
+
 ## Events published
 | Event | When |
 |---|---|


### PR DESCRIPTION
## Why

Working the booking controller (#85) revealed the intended flow runs **reserve → slot-reserved event → booking created**: reserving a slot is the guarded user-facing action (membership, authorization, availability all enforced there), and the booking is the ledger reacting to it. Nothing recorded this:

- `booking/COMPONENT.md` pointed the **other way** — "the caller (use case) is responsible for verifying the user is allowed to book before invoking this component" — an instruction that invites bolting authorization onto the booking-creation reaction, cementing the backwards flow.
- `slot/COMPONENT.md` had no flow information at all.
- The knowledge lived only in the *shape* of the Cucumber scenarios (guarded multi-scenario features = user commands; thin guard-free features = event reactions) — invisible to a code reader, since the event publisher is mocked in tests and the connective listeners are not wired. Any test reshuffle would erase it.

## What

**`booking/COMPONENT.md`** rewritten and **`slot/COMPONENT.md`** given a flow section, both at design level. The documents link without naming each other's consumers: slot says reserving publishes a slot-reserved event; booking says it reacts to a slot reserved by a person by creating the booking.

**`CLAUDE.md`** gains a *Component flow documentation* section (last subsection of Architecture Rules) and a Hard Constraints bullet. The rules:

- Written from the user's point of view: guarded **commands** vs unguarded **reactions** (the guarded command that produced the event already validated everything).
- Each component documents what it **publishes** and what it **reacts to** — never who consumes its events; events are asynchronous and decoupled, flows are reconstructed by linking documents.
- **Never** class/method/file/endpoint names — naming conventions locate the code without pinning its name.
- **Never** gaps or wiring status — a discovered gap becomes a story on the component's epic or a transverse one.
- Flow changes and flow discoveries update the affected `COMPONENT.md` files in the same change.

**Skills** close the loop: `develop-use-case` and `develop-controller` gain a final flow-documentation step, `develop-story-e2e`'s Step 7 follows the same rules, and `manage-backlog-item` records that flow gaps become stories.

## Notes

- Docs-only change — no code, no tests affected.
- The gaps this discovery surfaced are going to the board (reserve API entry point; wiring the reactions; amending #252), not into these documents, per the rule itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)